### PR TITLE
fix: handle unconfigured providers in get_available_chat_models

### DIFF
--- a/forge/forge/llm/providers/multi.py
+++ b/forge/forge/llm/providers/multi.py
@@ -69,7 +69,11 @@ class MultiProvider(BaseChatModelProvider[ModelName, ModelProviderSettings]):
     async def get_available_chat_models(self) -> Sequence[ChatModelInfo[ModelName]]:
         models = []
         for provider in self.get_available_providers():
-            models.extend(await provider.get_available_chat_models())
+            if hasattr(provider, 'is_configured') and provider.is_configured():
+                try:
+                    models.extend(await provider.get_available_chat_models())
+                except Exception as e:
+                    logger.warning(f"Failed to get models from {provider.__class__.__name__}: {e}")
         return models
 
     def get_token_limit(self, model_name: ModelName) -> int:


### PR DESCRIPTION
Added a check to ensure that only configured providers are queried for available chat models. Added exception handling to log warnings when a provider fails to return models, improving robustness and debugging capabilities.

### Background

<!-- Clearly explain the need for these changes: -->

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
